### PR TITLE
Udpate default port to 3000

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,6 @@ export default defineConfig({
 	],
 	server: {
 		host: true,
-		port: process.env.PORT ? +process.env.PORT : 5173,
+		port: process.env.PORT ? +process.env.PORT : 3000,
 	},
 });


### PR DESCRIPTION
### Summary
- When you don't have the `.env` file tests wont run properly because of the default port doesn't match the one that cypress is checking

### Details
- Udpate default port to 3000
