### PR TITLE
Fix method update cache

### DIFF
--- a/src/common/api/invocations.ts
+++ b/src/common/api/invocations.ts
@@ -160,7 +160,6 @@ export const useDeleteInvocationMutation = () => {
 };
 
 export const useEditInvocationKeysMutation = () => {
-	const queryClient = useQueryClient();
 	const axios = useAxios();
 
 	const mutation = useMutation({
@@ -180,9 +179,6 @@ export const useEditInvocationKeysMutation = () => {
 					publicKey,
 				})
 				.then((res) => res.data),
-		onSuccess: (_, { id }) => {
-			queryClient.invalidateQueries({ queryKey: ['invocation', id] });
-		},
 	});
 
 	return mutation;

--- a/src/common/api/methods.ts
+++ b/src/common/api/methods.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import useAxios from '../hooks/useAxios';
 import { Method } from '../types/method';
@@ -16,6 +16,7 @@ export const useMethodQuery = ({ id }: { id?: string }) => {
 };
 
 export const useEditParametersMethodMutation = () => {
+	const queryClient = useQueryClient();
 	const axios = useAxios();
 
 	const mutation = useMutation({
@@ -32,6 +33,9 @@ export const useEditParametersMethodMutation = () => {
 					params: parameters,
 				})
 				.then((res) => res.data),
+		onSettled: (_, __, { id }) => {
+			queryClient.invalidateQueries({ queryKey: ['method', id] });
+		},
 	});
 
 	return mutation;

--- a/src/common/components/Input/FunctionParameter.tsx
+++ b/src/common/components/Input/FunctionParameter.tsx
@@ -16,7 +16,7 @@ const FunctionParameterInput = ({
 }: {
 	control: Control<ParametersFormType>;
 	index: number;
-	onDelete: () => void;
+	onDelete?: () => void;
 	defaultParameters: {
 		name: string;
 		type: string;
@@ -69,14 +69,16 @@ const FunctionParameterInput = ({
 				)}
 			/>
 
-			<Button
-				onClick={onDelete}
-				variant={'ghost'}
-				size={'icon'}
-				className="min-w-[42px]"
-			>
-				<DeleteIcon size="20" className="text-primary" />
-			</Button>
+			{onDelete && (
+				<Button
+					onClick={onDelete}
+					variant={'ghost'}
+					size={'icon'}
+					className="min-w-[42px]"
+				>
+					<DeleteIcon size="20" className="text-primary" />
+				</Button>
+			)}
 		</div>
 	);
 };

--- a/src/common/components/Tabs/AuthorizationTab/AuthorizationTab.tsx
+++ b/src/common/components/Tabs/AuthorizationTab/AuthorizationTab.tsx
@@ -6,12 +6,18 @@ import { Input } from '../../ui/input';
 
 import { useEditInvocationKeysMutation } from '@/common/api/invocations';
 
-const AuthorizationTab = ({ invocationId }: { invocationId: string }) => {
+const AuthorizationTab = ({
+	invocationId,
+	defaultValues,
+}: {
+	invocationId: string;
+	defaultValues: { secretKey?: string; publicKey?: string };
+}) => {
 	const { mutate: editKeys } = useEditInvocationKeysMutation();
 	const { register, reset, formState, watch } = useForm({
 		defaultValues: {
-			secretKey: '',
-			publicKey: '',
+			secretKey: defaultValues.secretKey,
+			publicKey: defaultValues.publicKey,
 		},
 	});
 	const data = watch();

--- a/src/common/components/Tabs/FunctionsTab/ParametersForm.tsx
+++ b/src/common/components/Tabs/FunctionsTab/ParametersForm.tsx
@@ -19,7 +19,7 @@ const ParametersFormContent = ({ data }: { data: Method }) => {
 			parameters: data?.params,
 		},
 	});
-	const { fields, remove } = useFieldArray({
+	const { fields } = useFieldArray({
 		control,
 		name: 'parameters',
 	});
@@ -66,7 +66,6 @@ const ParametersFormContent = ({ data }: { data: Method }) => {
 							key={field.name}
 							index={index}
 							control={control}
-							onDelete={() => remove(index)}
 							defaultParameters={data.inputs ?? []}
 						/>
 					))}
@@ -108,7 +107,7 @@ const ParametersForm = ({
 		return null;
 	}
 
-	return <ParametersFormContent data={data} />;
+	return <ParametersFormContent key={data.id} data={data} />;
 };
 
 export default ParametersForm;

--- a/src/common/types/invocation.ts
+++ b/src/common/types/invocation.ts
@@ -11,6 +11,8 @@ export type Invocation = {
 	methods?: Method[];
 	selectedMethod?: Method;
 	parameters?: { key: string; value: string }[] | null;
+	secretKey?: string;
+	publicKey?: string;
 };
 
 export const SCSpecTypeMap = {

--- a/src/pages/Invocation/InvocationPage.tsx
+++ b/src/pages/Invocation/InvocationPage.tsx
@@ -103,7 +103,13 @@ const InvocationPageContent = ({ data }: { data: Invocation }) => {
 					/>
 				</TabsContent>
 				<TabsContent value="authorization">
-					<AuthorizationTab invocationId={data.id} />
+					<AuthorizationTab
+						invocationId={data.id}
+						defaultValues={{
+							secretKey: data.secretKey,
+							publicKey: data.publicKey,
+						}}
+					/>
 				</TabsContent>
 			</Tabs>
 			<Terminal />


### PR DESCRIPTION
### Summary
- There is currently a bug where switching methods it's not showing the correct parameters

### Details
- Remove unnecesary query invalidation when updating invocation keys
- Refresh method query when updating params
- Add default secret and public keys default values

### Evidence
