### PR TITLE
Fix empty param value

### DIFF
--- a/src/common/components/Tabs/FunctionsTab/ParametersForm.tsx
+++ b/src/common/components/Tabs/FunctionsTab/ParametersForm.tsx
@@ -38,9 +38,10 @@ const ParametersFormContent = ({ data }: { data: Method }) => {
 					id: data.id,
 					parameters: value.map((param: Parameter) => ({
 						name: param.name,
-						value: isNaN(Number(param.value))
-							? param.value
-							: Number(param.value),
+						value:
+							isNaN(Number(param.value)) || !param.value
+								? param.value
+								: Number(param.value),
 					})),
 				});
 				reset({


### PR DESCRIPTION
### Summary
- We are by mistake converting empty param values into `0`

### Details
- Check if `param.value` exists before setting the value
