### PR TITLE
Chore: replace soroban to stellar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,8 @@
 				"react-hook-form": "^7.47.0",
 				"react-query": "^3.39.3",
 				"react-router-dom": "^6.11.1",
-				"soroban-client": "^1.0.0-beta.3",
 				"sort-by": "^0.0.2",
+				"stellar-sdk": "^11.0.1",
 				"tailwind-merge": "^1.14.0",
 				"tailwindcss-animate": "^1.0.7",
 				"use-debounce": "^10.0.0"
@@ -6680,6 +6680,55 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
+		"node_modules/@stellar/js-xdr": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.0.1.tgz",
+			"integrity": "sha512-dp5Eh7Nr1YjiIeqpdkj2cQYxfoPudDAH3ck8MWggp48Htw66Z/hUssNYUQG/OftLjEmHT90Z/dtey2Y77DOxIw=="
+		},
+		"node_modules/@stellar/stellar-base": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-10.0.0.tgz",
+			"integrity": "sha512-zHlGzWefiB2gkt13l+I8Dvo2k7+n6+vxizay4lDEc5si0zjSZbCUUzMIdVIQ86dao7+TvZ3aNw8CdncOWLDu2A==",
+			"dependencies": {
+				"@stellar/js-xdr": "^3.0.1",
+				"base32.js": "^0.1.0",
+				"bignumber.js": "^9.1.2",
+				"buffer": "^6.0.3",
+				"sha.js": "^2.3.6",
+				"tweetnacl": "^1.0.3"
+			},
+			"optionalDependencies": {
+				"sodium-native": "^4.0.1"
+			}
+		},
+		"node_modules/@stellar/stellar-base/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/@stellar/stellar-base/node_modules/tweetnacl": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+		},
 		"node_modules/@tanstack/query-core": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.0.0.tgz",
@@ -10081,6 +10130,14 @@
 				"node": ">=0.8.x"
 			}
 		},
+		"node_modules/eventsource": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+			"integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/execa": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
@@ -12383,11 +12440,6 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
-		"node_modules/js-xdr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-3.0.0.tgz",
-			"integrity": "sha512-tSt6UKJ2L7t+yaQURGkHo9kop9qnVbChTlCu62zNiDbDZQoZb/YjUj2iFJ3lgelhfg9p5bhO2o/QX+g36TPsSQ=="
-		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -14312,9 +14364,9 @@
 			}
 		},
 		"node_modules/node-gyp-build": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-			"integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
+			"integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==",
 			"optional": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
@@ -15594,8 +15646,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -16765,41 +16815,6 @@
 				"node-gyp-build": "^4.6.0"
 			}
 		},
-		"node_modules/soroban-client": {
-			"version": "1.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-1.0.0-beta.3.tgz",
-			"integrity": "sha512-BnySnAKmSaDTMn+QV50jpJ24+sxwsUyi78Et120o4lzxyya0MXTXyx2toqVBGrTdEubjO0Fy4+bc+1jkbvGSOg==",
-			"dependencies": {
-				"axios": "^1.4.0",
-				"bignumber.js": "^9.1.1",
-				"buffer": "^6.0.3",
-				"stellar-base": "v10.0.0-beta.3",
-				"urijs": "^1.19.1"
-			}
-		},
-		"node_modules/soroban-client/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
 		"node_modules/sort-by": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/sort-by/-/sort-by-0.0.2.tgz",
@@ -17094,49 +17109,19 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/stellar-base": {
-			"version": "10.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-10.0.0-beta.3.tgz",
-			"integrity": "sha512-+B1fOdsDWJEnYSYkKSAVHVngzaqDtD8wdDMT/FC+11MrohP3uGY1OmrEeVn34jiBmUlpYZVudDnpDMSXD4RqDA==",
+		"node_modules/stellar-sdk": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-11.0.1.tgz",
+			"integrity": "sha512-uRXK9NcsJNoo7F2P3JQRY9GC9+LFVQQjz9N5nmsLdUDrOT9cM8bb3MoUt9jdY5+nBsrEVnuJTZzLG29GyowBew==",
 			"dependencies": {
-				"base32.js": "^0.1.0",
+				"@stellar/stellar-base": "10.0.0",
+				"axios": "^1.6.0",
 				"bignumber.js": "^9.1.2",
-				"buffer": "^6.0.3",
-				"js-xdr": "^3.0.0",
-				"sha.js": "^2.3.6",
-				"tweetnacl": "^1.0.3"
-			},
-			"optionalDependencies": {
-				"sodium-native": "^4.0.1"
+				"eventsource": "^2.0.2",
+				"randombytes": "^2.1.0",
+				"toml": "^3.0.0",
+				"urijs": "^1.19.1"
 			}
-		},
-		"node_modules/stellar-base/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/stellar-base/node_modules/tweetnacl": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
 		},
 		"node_modules/stream-combiner": {
 			"version": "0.0.4",
@@ -17694,6 +17679,11 @@
 			"engines": {
 				"node": ">=0.6"
 			}
+		},
+		"node_modules/toml": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
 		},
 		"node_modules/tough-cookie": {
 			"version": "4.1.3",
@@ -23422,6 +23412,41 @@
 				}
 			}
 		},
+		"@stellar/js-xdr": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.0.1.tgz",
+			"integrity": "sha512-dp5Eh7Nr1YjiIeqpdkj2cQYxfoPudDAH3ck8MWggp48Htw66Z/hUssNYUQG/OftLjEmHT90Z/dtey2Y77DOxIw=="
+		},
+		"@stellar/stellar-base": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-10.0.0.tgz",
+			"integrity": "sha512-zHlGzWefiB2gkt13l+I8Dvo2k7+n6+vxizay4lDEc5si0zjSZbCUUzMIdVIQ86dao7+TvZ3aNw8CdncOWLDu2A==",
+			"requires": {
+				"@stellar/js-xdr": "^3.0.1",
+				"base32.js": "^0.1.0",
+				"bignumber.js": "^9.1.2",
+				"buffer": "^6.0.3",
+				"sha.js": "^2.3.6",
+				"sodium-native": "^4.0.1",
+				"tweetnacl": "^1.0.3"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "6.0.3",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+					"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.2.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+					"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+				}
+			}
+		},
 		"@tanstack/query-core": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.0.0.tgz",
@@ -26001,6 +26026,11 @@
 			"dev": true,
 			"peer": true
 		},
+		"eventsource": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+			"integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
+		},
 		"execa": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
@@ -27663,11 +27693,6 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
-		"js-xdr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-3.0.0.tgz",
-			"integrity": "sha512-tSt6UKJ2L7t+yaQURGkHo9kop9qnVbChTlCu62zNiDbDZQoZb/YjUj2iFJ3lgelhfg9p5bhO2o/QX+g36TPsSQ=="
-		},
 		"js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -29144,9 +29169,9 @@
 			}
 		},
 		"node-gyp-build": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-			"integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
+			"integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==",
 			"optional": true
 		},
 		"node-int64": {
@@ -30043,8 +30068,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"peer": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -30914,29 +30937,6 @@
 				"node-gyp-build": "^4.6.0"
 			}
 		},
-		"soroban-client": {
-			"version": "1.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-1.0.0-beta.3.tgz",
-			"integrity": "sha512-BnySnAKmSaDTMn+QV50jpJ24+sxwsUyi78Et120o4lzxyya0MXTXyx2toqVBGrTdEubjO0Fy4+bc+1jkbvGSOg==",
-			"requires": {
-				"axios": "^1.4.0",
-				"bignumber.js": "^9.1.1",
-				"buffer": "^6.0.3",
-				"stellar-base": "v10.0.0-beta.3",
-				"urijs": "^1.19.1"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "6.0.3",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-					"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-					"requires": {
-						"base64-js": "^1.3.1",
-						"ieee754": "^1.2.1"
-					}
-				}
-			}
-		},
 		"sort-by": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/sort-by/-/sort-by-0.0.2.tgz",
@@ -31164,34 +31164,18 @@
 			"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
 			"peer": true
 		},
-		"stellar-base": {
-			"version": "10.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-10.0.0-beta.3.tgz",
-			"integrity": "sha512-+B1fOdsDWJEnYSYkKSAVHVngzaqDtD8wdDMT/FC+11MrohP3uGY1OmrEeVn34jiBmUlpYZVudDnpDMSXD4RqDA==",
+		"stellar-sdk": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-11.0.1.tgz",
+			"integrity": "sha512-uRXK9NcsJNoo7F2P3JQRY9GC9+LFVQQjz9N5nmsLdUDrOT9cM8bb3MoUt9jdY5+nBsrEVnuJTZzLG29GyowBew==",
 			"requires": {
-				"base32.js": "^0.1.0",
+				"@stellar/stellar-base": "10.0.0",
+				"axios": "^1.6.0",
 				"bignumber.js": "^9.1.2",
-				"buffer": "^6.0.3",
-				"js-xdr": "^3.0.0",
-				"sha.js": "^2.3.6",
-				"sodium-native": "^4.0.1",
-				"tweetnacl": "^1.0.3"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "6.0.3",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-					"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-					"requires": {
-						"base64-js": "^1.3.1",
-						"ieee754": "^1.2.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-					"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-				}
+				"eventsource": "^2.0.2",
+				"randombytes": "^2.1.0",
+				"toml": "^3.0.0",
+				"urijs": "^1.19.1"
 			}
 		},
 		"stream-combiner": {
@@ -31609,6 +31593,11 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
 			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
 			"peer": true
+		},
+		"toml": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
 		},
 		"tough-cookie": {
 			"version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
 		"react-hook-form": "^7.47.0",
 		"react-query": "^3.39.3",
 		"react-router-dom": "^6.11.1",
-		"soroban-client": "^1.0.0-beta.3",
 		"sort-by": "^0.0.2",
+		"stellar-sdk": "^11.0.1",
 		"tailwind-merge": "^1.14.0",
 		"tailwindcss-animate": "^1.0.7",
 		"use-debounce": "^10.0.0"

--- a/src/services/stellar/hook/useStellar.tsx
+++ b/src/services/stellar/hook/useStellar.tsx
@@ -1,4 +1,4 @@
-import { Keypair } from 'soroban-client';
+import { Keypair } from 'stellar-sdk';
 
 import { IKeypair } from '../domain/keypair';
 import { STELLAR_RESPONSE } from '../validators/stellarExceptions';


### PR DESCRIPTION
### Summary

- Dependency is changed since `soroban-client` is deprecated

### Details

- Replace `soroban-client` to `stellar-sdk`

