### PR TITLE
Feature: Fix environments endpoint && Change import of environments

### DIFF
--- a/src/common/api/enviroments.ts
+++ b/src/common/api/enviroments.ts
@@ -15,7 +15,7 @@ export const useEnvironmentsQuery = ({
 		queryKey: ['environment', collectionId],
 		queryFn: async () =>
 			axios
-				?.get(`/colletion/${collectionId}/environments`)
+				?.get(`/collection/${collectionId}/environments`)
 				.then((res) => res.data),
 	});
 

--- a/src/common/components/Collections/CollectionVariables.tsx
+++ b/src/common/components/Collections/CollectionVariables.tsx
@@ -107,17 +107,18 @@ export const CollectionVariables = ({
 				className="flex flex-col gap-2 px-1 pt-12"
 				data-test="collection-variables-input-container"
 			>
-				{fields.map((environment, index) => (
-					<EnvironmentItem
-						key={index}
-						environment={environment}
-						index={index}
-						collectionId={collectionId}
-						control={control}
-						removeItem={remove}
-						deleteMutation={handleRemoveEnvironment}
-					/>
-				))}
+				{fields.length > 0 &&
+					fields.map((environment, index) => (
+						<EnvironmentItem
+							key={index}
+							environment={environment}
+							index={index}
+							collectionId={collectionId}
+							control={control}
+							removeItem={remove}
+							deleteMutation={handleRemoveEnvironment}
+						/>
+					))}
 			</ul>
 			<div className="flex justify-end pt-4 mr-8">
 				<Button type="submit" className="font-semibold">

--- a/src/common/components/Collections/CollectionVariablesContainer.tsx
+++ b/src/common/components/Collections/CollectionVariablesContainer.tsx
@@ -5,16 +5,19 @@ import { useParams } from 'react-router-dom';
 import { CollectionVariables } from './CollectionVariables';
 
 import { useCollectionQuery } from '@/common/api/collections';
-import useEnvironments from '@/common/hooks/useEnvironments';
+import { useEnvironmentsQuery } from '@/common/api/enviroments';
 
 export const CollectionVariablesContainer = () => {
 	const params = useParams();
-	const { environments, isLoading } = useEnvironments();
-
 	const collectionId = React.useMemo(() => {
 		return params.collectionId ?? '';
 	}, [params]);
 	const { data: collection } = useCollectionQuery(collectionId);
+	const { data, isLoading } = useEnvironmentsQuery({ collectionId });
+
+	const environmentsValue = React.useMemo(() => {
+		return data ? data : [];
+	}, [data]);
 
 	if (isLoading) {
 		return (
@@ -28,7 +31,7 @@ export const CollectionVariablesContainer = () => {
 		<CollectionVariables
 			collection={collection}
 			collectionId={collectionId}
-			environments={environments}
+			environments={environmentsValue}
 		/>
 	);
 };


### PR DESCRIPTION
### Summary

Modify the endpoint from which we receive the environment variables linked to a collection
Modify where we receive the environment variables from

### Details

Update `environments service`
Update `CollectionsVariablesContainer`. Use environments query to get environments and not from custom hook

