### PR TITLE
Bind Keizai to pre invocation

### DIFF
--- a/src/pages/Invocation/useInvocation.tsx
+++ b/src/pages/Invocation/useInvocation.tsx
@@ -99,7 +99,12 @@ const useInvocation = (invocation: Invocation) => {
 		);
 
 		try {
-			const preInvocationResponse = eval(preInvocation);
+			const contextFunction = function () {
+				eval(preInvocation);
+			}.bind({ Keizai });
+
+			const preInvocationResponse = contextFunction();
+
 			return {
 				isError: false,
 				message: String(preInvocation),


### PR DESCRIPTION
### Summary
- We are currently no binding Keizai to the preinvocation script and this is causing Keizai to be not found when running the script.

### Details
- Bind Keizai to pre invocation
