### PR TITLE
Disable autocomplete in parameter value input

### DIFF
--- a/src/common/components/Input/FunctionParameter.tsx
+++ b/src/common/components/Input/FunctionParameter.tsx
@@ -81,6 +81,7 @@ const FunctionParameterInput = ({
 								ref={valueRef}
 								placeholder="Parameter value"
 								data-test="function-tab-parameter-input-value"
+								autoComplete="off"
 								onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
 									handleSearchEnvironment(e.target.value);
 									valueField.onChange(e);


### PR DESCRIPTION
### Summary
- Currently it's a bit annoying using collection variables in the input as it shows both native autocomplete and collection variables autocomplete

### Details
- Disable autocomplete in parameter value input

### Evidence
