### PR TITLE
Feat: Add Warning dialog to change network

### DIFF
--- a/cypress/fixtures/invocations/one-invocation-testnet.json
+++ b/cypress/fixtures/invocations/one-invocation-testnet.json
@@ -4,7 +4,7 @@
 	"publicKey": null,
 	"contractId": null,
 	"id": "635bbf80-0787-47e2-900c-f44d5f53559d",
-	"method": "TESTNET",
+	"network": "TESTNET",
 	"folder": {
 		"name": "Folder",
 		"id": "5ffed16a-6c59-4543-afb5-7c0f85e0723e"

--- a/cypress/fixtures/invocations/one-invocation.json
+++ b/cypress/fixtures/invocations/one-invocation.json
@@ -4,7 +4,7 @@
 	"publicKey": null,
 	"contractId": null,
 	"id": "635bbf80-0787-47e2-900c-f44d5f53559d",
-	"entwork": "FUTURENET",
+	"network": "FUTURENET",
 	"folder": {
 		"name": "Folder",
 		"id": "5ffed16a-6c59-4543-afb5-7c0f85e0723e"

--- a/cypress/fixtures/invocations/one-invocation.json
+++ b/cypress/fixtures/invocations/one-invocation.json
@@ -4,7 +4,7 @@
 	"publicKey": null,
 	"contractId": null,
 	"id": "635bbf80-0787-47e2-900c-f44d5f53559d",
-	"method": "FUTURENET",
+	"entwork": "FUTURENET",
 	"folder": {
 		"name": "Folder",
 		"id": "5ffed16a-6c59-4543-afb5-7c0f85e0723e"

--- a/cypress/tests/ui/exceptions/constants.ts
+++ b/cypress/tests/ui/exceptions/constants.ts
@@ -181,6 +181,17 @@ export const environments = {
 	],
 };
 
+export const changeNetwork = {
+	alertDialog: {
+		header: 'Update Network',
+		title: 'Warning!',
+		description:
+			'This will remove your current loaded contract, keys, functions and parameters.',
+		btnCancel: 'Cancel',
+		btnConfirm: 'Change',
+	},
+};
+
 export enum NETWORK {
 	FUTURENET = 'FUTURENET',
 	TESTNET = 'TESTNET',

--- a/src/common/api/invocations.ts
+++ b/src/common/api/invocations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 
+import { useToast } from '../components/ui/use-toast';
 import useAxios from '../hooks/useAxios';
 import { Invocation, InvocationResponse } from '../types/invocation';
 
@@ -161,6 +162,7 @@ export const useDeleteInvocationMutation = () => {
 export const useEditNetworkMutation = () => {
 	const queryClient = useQueryClient();
 	const axios = useAxios();
+	const { toast } = useToast();
 
 	const mutation = useMutation({
 		mutationFn: async ({ network, id }: { network: string; id: string }) =>
@@ -182,6 +184,20 @@ export const useEditNetworkMutation = () => {
 			return {
 				previousInvocation,
 			};
+		},
+		onError: () => {
+			toast({
+				title: 'Something went wrong!',
+				description: "Couldn't change network, please try again",
+				variant: 'destructive',
+			});
+		},
+		onSuccess: (_, { id }) => {
+			queryClient.invalidateQueries({ queryKey: ['invocation', id] });
+			toast({
+				title: 'Successfully!',
+				description: 'Network has been changed',
+			});
 		},
 	});
 	return mutation;

--- a/src/common/components/Input/ContractInput.tsx
+++ b/src/common/components/Input/ContractInput.tsx
@@ -3,19 +3,11 @@ import React from 'react';
 
 import EnvironmentDropdownContainer from '../Environments/EnvironmentDropdownContainer';
 import SaveContractDialog from './SaveContractDialog';
+import SelectNetwork from './SelectNetwork';
 
 import { Button } from '@/common/components/ui/button';
 import { Input } from '@/common/components/ui/input';
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from '@/common/components/ui/select';
 import useEnvironments from '@/common/hooks/useEnvironments';
-import useNetwork from '@/common/hooks/useNetwork';
-import { NETWORK } from '@/common/types/soroban.enum';
 
 const ContractInput = ({
 	defaultValue = '',
@@ -35,7 +27,6 @@ const ContractInput = ({
 		React.useState(false);
 	const { showEnvironments, handleSelectEnvironment, handleSearchEnvironment } =
 		useEnvironments();
-	const { selectNetwork, handleUpdateNetwork } = useNetwork(defaultNetwork);
 
 	const handleUpdateContractId = async () => {
 		if (contractId) {
@@ -52,33 +43,7 @@ const ContractInput = ({
 			className="flex items-center border p-2 rounded-md"
 			data-test="contract-input-container"
 		>
-			<Select value={selectNetwork} onValueChange={handleUpdateNetwork}>
-				<SelectTrigger
-					className="max-w-[140px] border-none text-slate-500 font-semibold"
-					data-test="contract-input-network"
-				>
-					<SelectValue
-						aria-label={selectNetwork}
-						data-test="contract-input-selected-network"
-					>
-						{selectNetwork}
-					</SelectValue>
-				</SelectTrigger>
-				<SelectContent data-test="contract-select-networks-container">
-					<SelectItem
-						value={NETWORK.SOROBAN_FUTURENET}
-						data-test="contract-select-network-futurenet"
-					>
-						{NETWORK.SOROBAN_FUTURENET}
-					</SelectItem>
-					<SelectItem
-						value={NETWORK.SOROBAN_TESTNET}
-						data-test="contract-select-network-testnet"
-					>
-						{NETWORK.SOROBAN_TESTNET}
-					</SelectItem>
-				</SelectContent>
-			</Select>
+			<SelectNetwork defaultNetwork={defaultNetwork} />
 			<div className="flex w-full group">
 				{defaultValue ? (
 					<div className="flex items-center justify-between flex-1 w-full relative">

--- a/src/common/components/Input/SelectNetwork.tsx
+++ b/src/common/components/Input/SelectNetwork.tsx
@@ -1,0 +1,120 @@
+import { AlertCircleIcon } from 'lucide-react';
+import React from 'react';
+
+import { Alert, AlertDescription, AlertTitle } from '../ui/alert';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '../ui/alert-dialog';
+
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/common/components/ui/select';
+import useNetwork from '@/common/hooks/useNetwork';
+import { NETWORK } from '@/common/types/soroban.enum';
+
+function SelectNetwork({ defaultNetwork }: { defaultNetwork: string }) {
+	const [showEditNetworkDialog, setShowEditNetworkDialog] =
+		React.useState(false);
+	const { selectNetwork, setSelectNetwork, handleUpdateNetwork } =
+		useNetwork(defaultNetwork);
+
+	const openEditNetworkDialog = (network: string) => {
+		setSelectNetwork(network);
+		setShowEditNetworkDialog(true);
+	};
+
+	const onConfirm = () => {
+		handleUpdateNetwork(selectNetwork);
+		setShowEditNetworkDialog(false);
+	};
+
+	const onCancel = () => {
+		setSelectNetwork(defaultNetwork);
+		setShowEditNetworkDialog(false);
+	};
+
+	return (
+		<>
+			<Select value={selectNetwork} onValueChange={openEditNetworkDialog}>
+				<SelectTrigger
+					className="max-w-[140px] border-none text-slate-500 font-semibold"
+					data-test="contract-input-network"
+				>
+					<SelectValue
+						aria-label={selectNetwork}
+						data-test="contract-input-selected-network"
+					>
+						{selectNetwork}
+					</SelectValue>
+				</SelectTrigger>
+				<SelectContent data-test="contract-select-networks-container">
+					<SelectItem
+						value={NETWORK.SOROBAN_FUTURENET}
+						data-test="contract-select-network-futurenet"
+					>
+						{NETWORK.SOROBAN_FUTURENET}
+					</SelectItem>
+					<SelectItem
+						value={NETWORK.SOROBAN_TESTNET}
+						data-test="contract-select-network-testnet"
+					>
+						{NETWORK.SOROBAN_TESTNET}
+					</SelectItem>
+				</SelectContent>
+			</Select>
+			{showEditNetworkDialog && (
+				<AlertDialog
+					open={showEditNetworkDialog}
+					onOpenChange={setShowEditNetworkDialog}
+				>
+					<AlertDialogContent data-test="change-network-dialog-container">
+						<AlertDialogHeader>
+							<AlertDialogTitle data-test="change-network-dialog-header-title">
+								Update Network
+							</AlertDialogTitle>
+							<AlertDialogDescription>
+								<Alert variant="destructive" className="my-5">
+									<AlertCircleIcon className="h-4 w-4" />
+									<AlertTitle data-test="change-network-dialog-title">
+										Warning!
+									</AlertTitle>
+									<AlertDescription data-test="change-network-dialog-description">
+										This will remove your current loaded contract, keys,
+										functions and parameters.
+									</AlertDescription>
+								</Alert>
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel
+								onClick={onCancel}
+								data-test="change-network-dialog-btn-cancel"
+							>
+								Cancel
+							</AlertDialogCancel>
+							<AlertDialogAction
+								onClick={onConfirm}
+								data-test="change-network-dialog-btn-continue"
+							>
+								Change
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			)}
+		</>
+	);
+}
+
+export default SelectNetwork;

--- a/src/common/hooks/useNetwork.ts
+++ b/src/common/hooks/useNetwork.ts
@@ -13,10 +13,9 @@ function useNetwork(defaultNetwork: string) {
 			network,
 			id: params.invocationId as string,
 		});
-		setSelectNetwork(network);
 	};
 
-	return { selectNetwork, handleUpdateNetwork };
+	return { selectNetwork, setSelectNetwork, handleUpdateNetwork };
 }
 
 export default useNetwork;


### PR DESCRIPTION
### Summary

- A warning is added via a dialog alert to notify the user that the invocation will be restarted.

### Details

- Add new component with input select network and alert dialog to change network,
- Add toast when change network is an error or success

### Evidence

![image](https://github.com/keizai-tools/keizai-ui/assets/60760903/7914ad0b-46fc-4ee5-ab0c-1081185b9c26)
![image](https://github.com/keizai-tools/keizai-ui/assets/60760903/eb75c996-0407-407c-920a-ddc188aef032)

https://github.com/keizai-tools/keizai-ui/assets/60760903/d7263d98-b4c9-4e33-8fe9-2d9fc9a90cbf


