### PR TITLE
Feat: Add remove events when change network

### DIFF
--- a/cypress/tests/ui/invocations.spec.ts
+++ b/cypress/tests/ui/invocations.spec.ts
@@ -187,6 +187,11 @@ describe('Invocations', () => {
 					.should('be.visible')
 					.and('have.text', NETWORK.TESTNET);
 				cy.getBySel('tabs-content-container').should('exist').and('be.visible');
+				cy.getBySel('functions-tabs-authorization').click();
+				cy.getBySel('auth-tab-secret-key').should('have.value', '');
+				cy.getBySel('auth-tab-public-key').should('have.value', '');
+				cy.getBySel('functions-tabs-events').click();
+				cy.getBySel('events-tab-empty-state-container').should('be.visible');
 			});
 			it('Should persist the network when changing routes', () => {
 				cy.intercept('PATCH', `${Cypress.env('apiUrl')}/invocation`, {
@@ -316,9 +321,7 @@ describe('Invocations', () => {
 				cy.getBySel('new-entity-dialog-btn-submit').click();
 				cy.wait('@invocation');
 				cy.wait('@getInvocation');
-
 				cy.getBySel('functions-tabs-events').click();
-				cy.getBySel('events-tab-container').should('be.visible');
 				cy.getBySel('events-tab-empty-state-container').should('be.visible');
 				cy.getBySel('events-tab-content-img')
 					.should('be.visible')

--- a/src/common/components/Input/SaveContractDialog.tsx
+++ b/src/common/components/Input/SaveContractDialog.tsx
@@ -11,6 +11,7 @@ import { Input } from '../ui/input';
 import { useToast } from '../ui/use-toast';
 
 import { useEditInvocationMutation } from '@/common/api/invocations';
+import useContractEvents from '@/common/hooks/useContractEvents';
 import useEnvironments from '@/common/hooks/useEnvironments';
 
 const SaveContractDialog = ({
@@ -23,6 +24,7 @@ const SaveContractDialog = ({
 	const { toast } = useToast();
 	const { invocationId } = useParams();
 	const { mutate, isPending } = useEditInvocationMutation();
+	const { removeEventsFromStorage } = useContractEvents();
 	const { showEnvironments, handleSelectEnvironment, handleSearchEnvironment } =
 		useEnvironments();
 	const { control, register, handleSubmit, setValue } = useForm({
@@ -57,6 +59,9 @@ const SaveContractDialog = ({
 					contractId: data.contractId,
 				},
 				{
+					onSuccess: () => {
+						removeEventsFromStorage(invocationId);
+					},
 					onError: () => {
 						toast({
 							title: "Couldn't save contract",

--- a/src/common/components/Tabs/EventsTab/EventEmptyState.tsx
+++ b/src/common/components/Tabs/EventsTab/EventEmptyState.tsx
@@ -1,26 +1,24 @@
 function EventEmptyState() {
 	return (
-		<div className="flex my-20 px-12">
-			<div
-				className="flex justify-center items-center"
-				data-test="events-tab-empty-state-container"
-			>
-				<img
-					src="/searching.svg"
-					alt="Search events"
-					width={300}
-					height={300}
-					loading="eager"
-					data-test="events-tab-content-img"
-				/>
-				<div className="flex flex-col gap-3">
-					<div
-						className="flex flex-col justify-center text-primary font-black"
-						data-test="events-tab-content-text"
-					>
-						<h2 className="text-4xl">Run the contract</h2>
-						<h2 className="text-3xl">to see the events</h2>
-					</div>
+		<div
+			className="flex justify-center items-center my-20 flex-1"
+			data-test="events-tab-empty-state-container"
+		>
+			<img
+				src="/searching.svg"
+				alt="Search events"
+				width={270}
+				height={270}
+				loading="eager"
+				data-test="events-tab-content-img"
+			/>
+			<div className="flex flex-col gap-3">
+				<div
+					className="flex flex-col justify-center text-primary font-black"
+					data-test="events-tab-content-text"
+				>
+					<h2 className="text-5xl">Run the contract</h2>
+					<h2 className="text-4xl">to see the events</h2>
 				</div>
 			</div>
 		</div>

--- a/src/common/components/Tabs/EventsTab/EventsTab.tsx
+++ b/src/common/components/Tabs/EventsTab/EventsTab.tsx
@@ -1,20 +1,26 @@
 import EventCard from './EventCard';
 import EventEmptyState from './EventEmptyState';
 
-import { EventResponse } from '@/common/types/contract-events';
+import useContractEvents from '@/common/hooks/useContractEvents';
 
-function EventsTab({ events }: { events: EventResponse[] }) {
+function EventsTab() {
+	const { contractEvents } = useContractEvents();
+
 	return (
-		<section
-			className="w-full h-[500px] overflow-hidden overflow-y-auto scrollbar scrollbar-w-2 scrollbar-h-1 scrollbar-track-background scrollbar-thumb-slate-700 scrollbar-thumb-rounded"
-			data-test="events-tab-container"
-		>
-			{events.length > 0 ? (
-				events.map((event) => <EventCard event={event} key={event.id} />)
+		<>
+			{contractEvents.length > 0 ? (
+				<section
+					className="w-full h-[500px] overflow-hidden overflow-y-auto scrollbar scrollbar-w-2 scrollbar-h-1 scrollbar-track-background scrollbar-thumb-slate-700 scrollbar-thumb-rounded"
+					data-test="events-tab-container"
+				>
+					{contractEvents.map((event) => (
+						<EventCard event={event} key={event.id} />
+					))}
+				</section>
 			) : (
 				<EventEmptyState />
 			)}
-		</section>
+		</>
 	);
 }
 

--- a/src/common/hooks/useContractEvents.ts
+++ b/src/common/hooks/useContractEvents.ts
@@ -23,7 +23,12 @@ function useContractEvents() {
 		);
 	};
 
-	return { contractEvents, handleSetContractEvents };
+	const removeEventsFromStorage = (invocationId: string) => {
+		sessionStorage.removeItem(`events-${invocationId}`);
+		setContractEvents([]);
+	};
+
+	return { contractEvents, handleSetContractEvents, removeEventsFromStorage };
 }
 
 export default useContractEvents;

--- a/src/common/hooks/useNetwork.ts
+++ b/src/common/hooks/useNetwork.ts
@@ -2,10 +2,12 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useEditNetworkMutation } from '../api/invocations';
+import useContractEvents from './useContractEvents';
 
 function useNetwork(defaultNetwork: string) {
 	const [selectNetwork, setSelectNetwork] = React.useState(defaultNetwork);
 	const { mutate } = useEditNetworkMutation();
+	const { removeEventsFromStorage } = useContractEvents();
 	const params = useParams();
 
 	const handleUpdateNetwork = async (network: string) => {
@@ -13,6 +15,7 @@ function useNetwork(defaultNetwork: string) {
 			network,
 			id: params.invocationId as string,
 		});
+		removeEventsFromStorage(params.invocationId as string);
 	};
 
 	return { selectNetwork, setSelectNetwork, handleUpdateNetwork };

--- a/src/pages/Invocation/InvocationPage.tsx
+++ b/src/pages/Invocation/InvocationPage.tsx
@@ -24,7 +24,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from '@/common/components/ui/tooltip';
-import useContractEvents from '@/common/hooks/useContractEvents';
 import useEditor from '@/common/hooks/useEditor';
 import { Invocation } from '@/common/types/invocation';
 
@@ -50,8 +49,6 @@ const InvocationPageContent = ({ data }: { data: Invocation }) => {
 		handleRunInvocation,
 		isRunningInvocation,
 	} = useInvocation(data);
-
-	const { contractEvents } = useContractEvents();
 
 	const preInvocationValue = React.useMemo(() => {
 		return data.preInvocation ?? '';
@@ -155,7 +152,7 @@ const InvocationPageContent = ({ data }: { data: Invocation }) => {
 					/>
 				</TabsContent>
 				<TabsContent value="events">
-					<EventsTab events={contractEvents} />
+					<EventsTab />
 				</TabsContent>
 			</Tabs>
 			<Terminal entries={contractResponses} />


### PR DESCRIPTION
### Summary

- Add remove events when change the network
- Fix show events

### Details

- Events are imported from the useContractEvents inside the EventsTab and not from the InvocationPage
 - Add `removeEventsFromStorage` in `useContractEvents` and `useNetwork`
- Refactor events tab view

### Evidence
