### PR TITLE
Feat: Add error handler when run contract

### DIFF
--- a/cypress/tests/ui/exceptions/constants.ts
+++ b/cypress/tests/ui/exceptions/constants.ts
@@ -234,11 +234,44 @@ export enum NETWORK {
 }
 
 export const terminal = {
-	error: [
-		{
-			title: 'Failed',
-			message:
-				'There was a problem running the contract. It may be down or not running on the corresponding network',
+	error: {
+		title: {
+			failed: 'Failed',
+			hostError: 'Host invocation failed',
 		},
-	],
+		message: {
+			failedRunContractDefault:
+				'There was a problem running the contract. It may be down or not running on the corresponding network',
+			sorobanContractErrors: [
+				'Caused by:\n    HostError: Error(Contract, #2)\n    \n    Event log (newest first):\n       0: [Diagnostic Event] contract:CDI7KTHGYGX6U76745F74WKBS7N7TUSIADWJ3L4WFXCJF2LQT63M4YJW, topics:[error, Error(Contract, #2)], data:"operation invalid on issuer"\n       1: [Diagnostic Event] topics:[fn_call, Bytes(d1f54ce6c1afea7fdfe74bfe594197dbf9d24800ec9daf962dc492e9709fb6ce), mint], data:[GAZLCLQEUDIAYAW7TV7FWHCN4YQY726DSAHKWTGZCQEXZCNFNUHDBEBQ, 100000]\n    \n    ',
+				'Caused by:\n    HostError: Error(Contract, #9)\n    \n    Event log (newest first):\n       0: [Diagnostic Event] contract:CDI7KTHGYGX6U76745F74WKBS7N7TUSIADWJ3L4WFXCJF2LQT63M4YJW, topics:[error, Error(Contract, #9)], data:["not enough allowance to spend", 0, 10000000]\n       1: [Diagnostic Event] topics:[fn_call, Bytes(d1f54ce6c1afea7fdfe74bfe594197dbf9d24800ec9daf962dc492e9709fb6ce), transfer_from], data:[GCSVX4SOXK4OBLXQH2PZNGSNWTFXEABJIL4JO63DLKTAVBQZQXCBCT4D, GAZLCLQEUDIAYAW7TV7FWHCN4YQY726DSAHKWTGZCQEXZCNFNUHDBEBQ, GBT45AFONOUKIX2PAXK3NEFYHKLH7WHJZJ7ZQX37BBEDSNCA3PJ4I7PW, 10000000]\n    \n    ',
+			],
+		},
+	},
 };
+
+export const transactionResultCode = {
+	txBadAuth:
+		'There was a problem, too few valid signatures or the wrong network',
+	txBadAuthExtra: 'Unused signatures attached to transaction',
+	txBadSeq: 'Sequence number does not match source account',
+	txFailed:
+		'Check the parameters or if the issuing account has sufficient balance',
+	txInsufficientBalance: 'Fee would bring account below reserve',
+	txInsufficientFee: 'There was a problem, fee is too small',
+	txMissingOperation: 'No operation was specified',
+	txTooEarly: 'The ledger closeTime was before the minTime',
+	txTooLate: 'The ledger closeTime was after the maxTime',
+};
+
+export const txErrorCode = [
+	'txBadAuth',
+	'txBadAuthExtra',
+	'txBadSeq',
+	'txFailed',
+	'txInsufficientBalance',
+	'txInsufficientFee',
+	'txMissingOperation',
+	'txTooEarly',
+	'txTooLate',
+];

--- a/src/common/components/Input/EnvironmentInput.tsx
+++ b/src/common/components/Input/EnvironmentInput.tsx
@@ -22,6 +22,8 @@ function EnvironmentInput({
 				envRegex,
 				(match) => `<span class="text-primary">${match}</span>`,
 			);
+		} else {
+			return code;
 		}
 	};
 

--- a/src/common/components/ui/Terminal.tsx
+++ b/src/common/components/ui/Terminal.tsx
@@ -6,7 +6,7 @@ export type TerminalEntry = {
 	preInvocation?: React.ReactNode;
 	postInvocation?: React.ReactNode;
 	title?: React.ReactNode;
-	message: string;
+	message: React.ReactNode | string;
 	isError: boolean;
 };
 

--- a/src/common/exceptions/invocations.ts
+++ b/src/common/exceptions/invocations.ts
@@ -8,3 +8,17 @@ export enum STATUS {
 	FAILED = 'FAILED',
 	SUCCESS = 'SUCCESS',
 }
+
+export const transactionResultCode = {
+	txBadAuth:
+		'There was a problem, too few valid signatures or the wrong network',
+	txBadAuthExtra: 'Unused signatures attached to transaction',
+	txBadSeq: 'Sequence number does not match source account',
+	txFailed:
+		'Check the parameters or if the issuing account has sufficient balance',
+	txInsufficientBalance: 'Fee would bring account below reserve',
+	txInsufficientFee: 'There was a problem, fee is too small',
+	txMissingOperation: 'No operation was specified',
+	txTooEarly: 'The ledger closeTime was before the minTime',
+	txTooLate: 'The ledger closeTime was after the maxTime',
+};

--- a/src/common/types/invocation.ts
+++ b/src/common/types/invocation.ts
@@ -22,6 +22,7 @@ export type Invocation = {
 export type InvocationResponse = {
 	method: Method;
 	response: string;
+	title?: string;
 	status: string;
 	events: EventResponse[];
 };

--- a/src/pages/Invocation/InvocationPage.tsx
+++ b/src/pages/Invocation/InvocationPage.tsx
@@ -61,7 +61,7 @@ const InvocationPageContent = ({ data }: { data: Invocation }) => {
 				postInvocationValue={postInvocationValue}
 				isMissingKeys={isMissingKeys}
 			/>
-			<Terminal entries={contractResponses} />
+			<Terminal entries={contractResponses.reverse()} />
 		</div>
 	);
 };

--- a/src/pages/Invocation/invocation.utils.tsx
+++ b/src/pages/Invocation/invocation.utils.tsx
@@ -1,7 +1,11 @@
 import { AxiosError, isAxiosError } from 'axios';
 import { AlertCircle, ChevronRight } from 'lucide-react';
 
-import { INVOCATION_RESPONSE, STATUS } from '@/common/exceptions/invocations';
+import {
+	INVOCATION_RESPONSE,
+	STATUS,
+	transactionResultCode,
+} from '@/common/exceptions/invocations';
 import { ApiError, isApiError } from '@/common/hooks/useAxios';
 import { InvocationResponse } from '@/common/types/invocation';
 import { Method } from '@/common/types/method';
@@ -77,7 +81,7 @@ export const handleAxiosError = (error: unknown) => {
 	};
 };
 
-export const failedRunContract = () => {
+export const failedRunContract = (response: string) => {
 	return {
 		isError: true,
 		title: (
@@ -86,7 +90,9 @@ export const failedRunContract = () => {
 				Failed
 			</div>
 		),
-		message: INVOCATION_RESPONSE.FAILED_RUN_CONTRACT,
+		message:
+			transactionResultCode[response as keyof typeof transactionResultCode] ??
+			INVOCATION_RESPONSE.FAILED_RUN_CONTRACT,
 	};
 };
 
@@ -112,11 +118,26 @@ export const getInvocationResponse = (
 					message: response.response || 'No response',
 				};
 			case STATUS.FAILED:
-				return failedRunContract();
-			default:
-				throw new Error();
+				return failedRunContract(response.response);
 		}
-	} else {
-		throw new Error();
 	}
+
+	if (response.status === 'ERROR' && response.title) {
+		return {
+			isError: true,
+			title: (
+				<div className="flex items-center gap-2 text-red-500 font-semibold">
+					<AlertCircle size={16} />
+					{response.title.charAt(0).toUpperCase() + response.title.slice(1)}
+				</div>
+			),
+			message: (
+				<pre className="text-xs pr-2 whitespace-pre-wrap">
+					{response.response}
+				</pre>
+			),
+		};
+	}
+
+	throw new Error();
 };


### PR DESCRIPTION
### Summary

- Added error handling when running a contract for failed transactions or soroban contract error.
- We handle 9 of the 11 failed transaction errors because the remaining 2 are handled before running a contract.
- Displayed the soroban contract error in console for user understanding
- 
### Details

- Added error handling by transaction or soroban contract error
- Fixed errors in displaying the `contractResponse` and `paramValue` of the `selectedMethod`

### Evidence

- Soroban contract error
![image](https://github.com/keizai-tools/keizai-ui/assets/60760903/71b12e8b-66e1-4890-b3a6-fd1e052f7de5)

- Transaction failed
![image](https://github.com/keizai-tools/keizai-ui/assets/60760903/0878218c-9119-458b-a96d-aacc68dd1d50)
