### PR TITLE
Feat: Add close dropdown when clicking outside

### DIFF
--- a/cypress/tests/ui/environments.spec.ts
+++ b/cypress/tests/ui/environments.spec.ts
@@ -408,6 +408,16 @@ describe('Environments management', () => {
 					.should('exist')
 					.and('be.visible');
 			});
+
+			it('Should hide dropdown when clicking outside', () => {
+				cy.getBySel('dropdown-environments-container').should('not.exist');
+				cy.getBySel('function-tab-parameter-input-value').type('{');
+				cy.getBySel('dropdown-environments-container')
+					.should('exist')
+					.and('be.visible');
+				cy.getBySel('breadcrumb-container').click();
+				cy.getBySel('dropdown-environments-container').should('not.exist');
+			});
 			it('Should show different environment values in the environment dropdown', () => {
 				cy.getBySel('dropdown-environments-container').should('not.exist');
 				cy.getBySel('function-tab-parameter-input-value').type('{');

--- a/src/common/components/Environments/EnvironmentDropdown.tsx
+++ b/src/common/components/Environments/EnvironmentDropdown.tsx
@@ -17,7 +17,7 @@ export default function EnvironmentDropdown({
 
 	return (
 		<div
-			className="dropdown-menu absolute bg-background text-white border w-96 max-h-64 rounded mt-0.5 mx-2 flex shadow"
+			className="dropdown-menu absolute bg-background text-white border w-96 max-h-64 rounded mt-0.5 mx-2 flex shadow z-50"
 			data-test="dropdown-environments-container"
 		>
 			{environments.length > 0 ? (

--- a/src/common/components/Environments/EnvironmentDropdownContainer.tsx
+++ b/src/common/components/Environments/EnvironmentDropdownContainer.tsx
@@ -9,17 +9,41 @@ type IProps = {
 	children: React.ReactNode;
 	showEnvironments: boolean;
 	handleSelect: (e: React.MouseEvent<HTMLLIElement, MouseEvent>) => void;
+	setShowEnvironments: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 function EnvironmentDropdownContainer({
 	children,
 	handleSelect,
 	showEnvironments,
+	setShowEnvironments,
 }: IProps) {
 	const { environments } = useEnvironments();
+	const dropdownRef = React.useRef<HTMLDivElement>(null);
+
+	React.useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (
+				dropdownRef.current &&
+				!dropdownRef.current.contains(event.target as Node)
+			) {
+				setShowEnvironments(false);
+			}
+		};
+
+		document.addEventListener('mousedown', handleClickOutside);
+
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, [setShowEnvironments, showEnvironments]);
 
 	return (
-		<div id="dropdown" className="z-10 divide-slate-800 rounded w-full">
+		<div
+			id="dropdown"
+			className="divide-slate-800 rounded w-full"
+			ref={dropdownRef}
+		>
 			{children}
 			{showEnvironments && (
 				<EnvironmentDropdown

--- a/src/common/components/Input/ContractInput.tsx
+++ b/src/common/components/Input/ContractInput.tsx
@@ -25,8 +25,12 @@ const ContractInput = ({
 	const [contractId, setContractId] = React.useState(defaultValue);
 	const [showEditContractDialog, setShowEditContractDialog] =
 		React.useState(false);
-	const { showEnvironments, handleSelectEnvironment, handleSearchEnvironment } =
-		useEnvironments();
+	const {
+		showEnvironments,
+		handleSelectEnvironment,
+		handleSearchEnvironment,
+		setShowEnvironments,
+	} = useEnvironments();
 
 	const handleUpdateContractId = async () => {
 		if (contractId) {
@@ -76,6 +80,7 @@ const ContractInput = ({
 					<EnvironmentDropdownContainer
 						handleSelect={handleSelect}
 						showEnvironments={showEnvironments}
+						setShowEnvironments={setShowEnvironments}
 					>
 						<EnvironmentInput
 							value={contractId}

--- a/src/common/components/Input/FunctionParameter.tsx
+++ b/src/common/components/Input/FunctionParameter.tsx
@@ -31,8 +31,12 @@ const FunctionParameterInput = ({
 	}[];
 	defaultValue: string;
 }) => {
-	const { showEnvironments, handleSelectEnvironment, handleSearchEnvironment } =
-		useEnvironments();
+	const {
+		showEnvironments,
+		handleSelectEnvironment,
+		handleSearchEnvironment,
+		setShowEnvironments,
+	} = useEnvironments();
 	const { setParamValue, paramValue } = useParameters({ defaultValue });
 	const valueRef = React.useRef<HTMLInputElement>(null);
 
@@ -94,6 +98,7 @@ const FunctionParameterInput = ({
 						<EnvironmentDropdownContainer
 							handleSelect={handleSelect}
 							showEnvironments={showEnvironments}
+							setShowEnvironments={setShowEnvironments}
 						>
 							<EnvironmentInput
 								value={valueField.value}

--- a/src/common/components/Input/SaveContractDialog.tsx
+++ b/src/common/components/Input/SaveContractDialog.tsx
@@ -25,8 +25,12 @@ const SaveContractDialog = ({
 	const { invocationId } = useParams();
 	const { mutate, isPending } = useEditInvocationMutation();
 	const { removeEventsFromStorage } = useContractEvents();
-	const { showEnvironments, handleSelectEnvironment, handleSearchEnvironment } =
-		useEnvironments();
+	const {
+		showEnvironments,
+		handleSelectEnvironment,
+		handleSearchEnvironment,
+		setShowEnvironments,
+	} = useEnvironments();
 	const { control, handleSubmit, setValue } = useForm({
 		defaultValues: {
 			contractId: '',
@@ -101,6 +105,7 @@ const SaveContractDialog = ({
 					<EnvironmentDropdownContainer
 						handleSelect={handleSelect}
 						showEnvironments={showEnvironments}
+						setShowEnvironments={setShowEnvironments}
 					>
 						<EnvironmentInput
 							value={contractId}

--- a/src/common/hooks/useEnvironments.ts
+++ b/src/common/hooks/useEnvironments.ts
@@ -42,5 +42,6 @@ export default function useEnvironments() {
 		selectEnvironment,
 		handleSearchEnvironment,
 		handleSelectEnvironment,
+		setShowEnvironments,
 	};
 }


### PR DESCRIPTION
### Summary

- Add close dropdown environments when clicking out of the element,
- Corrected the display of the environments dropdown above the parameter inputs.

### Details

- Add close dropdown when clicking outside
- Fix `z-index` in `DropdownContainer`
- Add `setShowenvironments` props

### Evidence

https://github.com/keizai-tools/keizai-ui/assets/60760903/c4ab8d5a-d192-46d3-8975-909f8aaeee1d


