### PR TITLE
Add invocationId to edit a method

### DIFF
--- a/src/common/api/methods.ts
+++ b/src/common/api/methods.ts
@@ -22,14 +22,17 @@ export const useEditParametersMethodMutation = () => {
 	const mutation = useMutation({
 		mutationFn: async ({
 			id,
+			invocationId,
 			parameters,
 		}: {
 			id: string;
+			invocationId: string;
 			parameters: { name: string; value: string }[];
 		}) =>
 			axios
 				?.patch(`/method`, {
 					id,
+					invocationId,
 					params: parameters,
 				})
 				.then((res) => res.data),

--- a/src/common/components/Tabs/FunctionsTab/FunctionsTab.tsx
+++ b/src/common/components/Tabs/FunctionsTab/FunctionsTab.tsx
@@ -63,7 +63,10 @@ const FunctionsTab = ({
 							))}
 						</SelectContent>
 					</Select>
-					<ParametersForm selectedMethodId={selectedMethod?.id} />
+					<ParametersForm
+						selectedMethodId={selectedMethod?.id}
+						invocationId={invocationId}
+					/>
 				</div>
 			) : (
 				<div

--- a/src/common/components/Tabs/FunctionsTab/ParametersForm.tsx
+++ b/src/common/components/Tabs/FunctionsTab/ParametersForm.tsx
@@ -12,7 +12,13 @@ import {
 import { Method, Parameter } from '@/common/types/method';
 
 export type ParametersFormType = { parameters: Method['params'] };
-const ParametersFormContent = ({ data }: { data: Method }) => {
+const ParametersFormContent = ({
+	data,
+	invocationId,
+}: {
+	data: Method;
+	invocationId: string;
+}) => {
 	const { mutate: editParameters } = useEditParametersMethodMutation();
 	const { control, watch, formState, reset, setValue } =
 		useForm<ParametersFormType>({
@@ -37,6 +43,7 @@ const ParametersFormContent = ({ data }: { data: Method }) => {
 			debounce((value) => {
 				editParameters({
 					id: data.id,
+					invocationId,
 					parameters: value.map((param: Parameter) => ({
 						name: param.name,
 						value:
@@ -49,7 +56,7 @@ const ParametersFormContent = ({ data }: { data: Method }) => {
 					parameters: value,
 				});
 			}, 500),
-		[data.id, editParameters, reset],
+		[data.id, editParameters, invocationId, reset],
 	);
 
 	React.useEffect(() => {
@@ -91,8 +98,10 @@ const ParametersFormContent = ({ data }: { data: Method }) => {
 
 const ParametersForm = ({
 	selectedMethodId,
+	invocationId,
 }: {
 	selectedMethodId?: string;
+	invocationId: string;
 }) => {
 	const { data, isLoading } = useMethodQuery({
 		id: selectedMethodId,
@@ -113,7 +122,13 @@ const ParametersForm = ({
 		return null;
 	}
 
-	return <ParametersFormContent key={data.id} data={data} />;
+	return (
+		<ParametersFormContent
+			key={data.id}
+			data={data}
+			invocationId={invocationId}
+		/>
+	);
 };
 
 export default ParametersForm;


### PR DESCRIPTION
### Summary

- We fix the parameters that we send to the backend to update a method.
- We added to send the invocationId so that it does not return an error from the backend.

### Details

- Add invocationId to edit a method

