### PR TITLE
Relocated console visibility toggle functions to Terminal component

### DIFF
--- a/src/common/components/Tabs/TabsContainer.tsx
+++ b/src/common/components/Tabs/TabsContainer.tsx
@@ -1,4 +1,3 @@
-import { Button } from '../ui/button';
 import EventsTab from './EventsTab/EventsTab';
 import FunctionsTab from './FunctionsTab/FunctionsTab';
 import PreInvocationTab from './PreInvocationTab/PreInvocationTab';
@@ -24,14 +23,12 @@ type TabsProps = {
   data: Invocation;
   preInvocationValue: string;
   postInvocationValue: string;
-  setIsTerminalVisible: (value: React.SetStateAction<boolean>) => void;
 };
 
 function TabsContainer({
   data,
   preInvocationValue,
   postInvocationValue,
-  setIsTerminalVisible,
 }: Readonly<TabsProps>) {
   const { setPreInvocationEditorValue, setPostInvocationEditorValue } =
     useEditor(preInvocationValue, postInvocationValue);
@@ -56,14 +53,6 @@ function TabsContainer({
             );
           })}
         </TabsList>
-        <Button
-          className="w-auto px-8 py-3 mx-2 font-bold transition-all duration-300 ease-in-out transform border-2 shadow-md hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          variant="outline"
-          onClick={() => setIsTerminalVisible((prev) => !prev)}
-          data-test="functions-tabs-console"
-        >
-          Console
-        </Button>
       </div>
       <TabsContent value="functions" className="h-full">
         <FunctionsTab

--- a/src/common/components/ui/Terminal.tsx
+++ b/src/common/components/ui/Terminal.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import { PanelBottomClose, PanelBottomOpen } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+
+import { Button } from './button';
 
 import { useResize } from '@/common/hooks/useResize';
 import { generateUniqueID } from '@/utils/functions/generateUniqueID';
@@ -11,7 +14,12 @@ export type TerminalEntry = {
   isError: boolean;
 };
 
-function Terminal({ entries }: Readonly<{ entries: TerminalEntry[] }>) {
+function Terminal({
+  entries,
+}: Readonly<{
+  entries: TerminalEntry[];
+}>) {
+  const [isTerminalVisible, setIsTerminalVisible] = useState(true);
   const terminalRef = React.useRef<HTMLDivElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
   const resizeTopRef = React.useRef<HTMLDivElement>(null);
@@ -32,56 +40,101 @@ function Terminal({ entries }: Readonly<{ entries: TerminalEntry[] }>) {
     }
   }, [onResizeCrossAxis]);
 
+  function toggleTerminalVisibility(event: KeyboardEvent) {
+    if (event.ctrlKey && event.key === 'j') {
+      event.preventDefault();
+      setIsTerminalVisible((prev) => !prev);
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('keydown', toggleTerminalVisibility);
+
+    return () => {
+      window.removeEventListener('keydown', toggleTerminalVisibility);
+    };
+  }, []);
+
   return (
-    <div
-      className="absolute inset-x-0 bottom-0 z-40 mx-3 bg-background"
-      data-test="terminal-container"
-      ref={containerRef}
-    >
+    <>
       <div
-        className="h-0.5 w-full border-t-2 dark:border-t-border border-zinc-600 cursor-ns-resize pb-4"
-        data-test="terminal-border-resize"
-        ref={resizeTopRef}
-      ></div>
-      <div
-        className="h-full pb-4 mx-2 overflow-y-auto text-zinc-600 scrollbar scrollbar-thumb-slate-700 scrollbar-w-2 scrollbar-thumb-rounded"
-        data-test="terminal-scrollbar-container"
+        className={`absolute inset-x-0 bottom-0 z-40 mx-3 bg-background transition-transform duration-300 ease-in-out ${
+          isTerminalVisible
+            ? 'transform translate-y-0'
+            : 'transform translate-y-full'
+        }`}
+        data-test="terminal-container"
+        ref={containerRef}
+        style={{ height: isTerminalVisible ? 'auto' : '0' }}
       >
-        <span className="font-bold">Welcome to keizai 1.0.0 - OUTPUT</span>
         <div
-          ref={terminalRef}
-          className="flex flex-col gap-4 py-5"
-          data-test="terminal-entry-container"
+          className="h-0.5 w-full border-t-2 dark:border-t-border border-zinc-600 cursor-ns-resize pb-4"
+          data-test="terminal-border-resize"
+          ref={resizeTopRef}
+        ></div>
+        <div
+          className={`overflow-y-auto text-zinc-600 scrollbar scrollbar-thumb-slate-700 scrollbar-w-2 scrollbar-thumb-rounded transition-opacity duration-300 ease-in-out ${
+            isTerminalVisible ? 'opacity-100' : 'opacity-0'
+          }`}
+          data-test="terminal-scrollbar-container"
+          style={{ height: isTerminalVisible ? 'auto' : '0' }}
         >
-          {entries
-            .slice()
-            .reverse()
-            .map((entry) => (
-              <div
-                key={generateUniqueID()}
-                className={`flex flex-col gap-1 text-sm text-zinc-200 ${
-                  entry.isError ? 'border-red-500' : 'border-green-700'
-                } border-l-2 pl-2`}
-                data-test="terminal-entry-title"
-              >
-                {entry.preInvocation}
-                {entry.title}
-                <span className="ml-4" data-test="terminal-entry-message">
-                  {entry.isError
-                    ? entry.message instanceof String ||
-                      typeof entry.message === 'string'
-                      ? entry.message
-                          ?.split('\n')
-                          .map((line, index) => <div key={index}>{line}</div>)
-                      : entry.message
-                    : JSON.stringify(entry.message, null, 2)}
-                </span>
-                {entry.postInvocation}
-              </div>
-            ))}
+          <div className="flex items-center gap-4">
+            <Button
+              variant="outline"
+              size="icon"
+              asChild
+              onClick={() => setIsTerminalVisible(false)}
+            >
+              <PanelBottomClose className="p-2 text-white transition-colors duration-300 cursor-pointer hover:text-primary" />
+            </Button>
+
+            <span className="font-bold">Welcome to keizai 1.0.0 - OUTPUT</span>
+          </div>
+          <div
+            ref={terminalRef}
+            className="flex flex-col gap-4 py-5"
+            data-test="terminal-entry-container"
+          >
+            {entries
+              .slice()
+              .reverse()
+              .map((entry) => (
+                <div
+                  key={generateUniqueID()}
+                  className={`flex flex-col gap-1 text-sm text-zinc-200 ${
+                    entry.isError ? 'border-red-500' : 'border-green-700'
+                  } border-l-2 pl-2`}
+                  data-test="terminal-entry-title"
+                >
+                  {entry.preInvocation}
+                  {entry.title}
+                  <span className="ml-4" data-test="terminal-entry-message">
+                    {entry.isError
+                      ? typeof entry.message === 'string'
+                        ? entry.message
+                            ?.split('\n')
+                            .map((line, index) => <div key={index}>{line}</div>)
+                        : entry.message
+                      : JSON.stringify(entry.message, null, 2)}
+                  </span>
+                  {entry.postInvocation}
+                </div>
+              ))}
+          </div>
         </div>
       </div>
-    </div>
+      {!isTerminalVisible && (
+        <Button
+          variant="outline"
+          size="icon"
+          asChild
+          onClick={() => setIsTerminalVisible(true)}
+        >
+          <PanelBottomOpen className="p-2 text-white transition-colors duration-300 cursor-pointer hover:text-primary" />
+        </Button>
+      )}
+    </>
   );
 }
 

--- a/src/pages/invocation/invocationPage.tsx
+++ b/src/pages/invocation/invocationPage.tsx
@@ -103,7 +103,6 @@ function InvocationPageContent({
   setLoading: (loading: boolean) => void;
 }>) {
   const { handleUpdateNetwork } = useNetwork(false);
-  const [isTerminalVisible, setIsTerminalVisible] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const {
@@ -133,13 +132,6 @@ function InvocationPageContent({
     setIsModalOpen(false);
   }
 
-  function toggleTerminalVisibility(event: KeyboardEvent) {
-    if (event.ctrlKey && event.key === 'j') {
-      event.preventDefault();
-      setIsTerminalVisible((prev) => !prev);
-    }
-  }
-
   function handleLoadContractWithLoading(contractId: string) {
     if (!loading && !isLoadingContract) setLoading(true);
     handleLoadContract(contractId);
@@ -148,14 +140,6 @@ function InvocationPageContent({
   useEffect(() => {
     if (data.contractId && loading) setLoading(false);
   }, [data, loading, setLoading]);
-
-  useEffect(() => {
-    window.addEventListener('keydown', toggleTerminalVisibility);
-
-    return () => {
-      window.removeEventListener('keydown', toggleTerminalVisibility);
-    };
-  }, []);
 
   return (
     <Fragment>
@@ -190,9 +174,8 @@ function InvocationPageContent({
               data={data}
               preInvocationValue={preInvocationValue}
               postInvocationValue={postInvocationValue}
-              setIsTerminalVisible={setIsTerminalVisible}
             />
-            {isTerminalVisible && <Terminal entries={contractResponses} />}
+            <Terminal entries={contractResponses} />
           </div>
         ) : (
           <InvocationCTAPage />


### PR DESCRIPTION
## Summary

This commit relocates the console visibility toggle functions to the `Terminal` component to centralize the functionality. As a result, the `TabsContainer` and `InvocationPageContent` components no longer manage the visibility state of the terminal directly.

## Details

### Modifications

1. **Updated `TabsContainer` Component**:
   - Removed the `setIsTerminalVisible` function and its associated button from `TabsContainer`.
   - Adjusted to no longer toggle terminal visibility.

2. **Enhanced `Terminal` Component**:
   - Added the visibility toggle logic to the `Terminal` component.
   - Implemented keyboard shortcuts to toggle the terminal visibility.

3. **Modified `InvocationPageContent` Component**:
   - Removed local terminal visibility management.
   - Relied on `Terminal` component for visibility control.

### Changes Overview

- **Files Changed**: 3
- **Lines Added**: 99
- **Lines Deleted**: 74

**File Changes:**

- `src/common/components/Tabs/TabsContainer.tsx`: 11 changes (0 additions & 11 deletions)
- `src/common/components/ui/Terminal.tsx`: 143 changes (98 additions & 45 deletions)
- `src/pages/invocation/invocationPage.tsx`: 19 changes (1 addition & 18 deletions)