### PR TITLE
Increases fetch interval for status updates

### DIFF
--- a/src/common/context/EphemeralContext.tsx
+++ b/src/common/context/EphemeralContext.tsx
@@ -95,7 +95,7 @@ export const EphemeralProvider = ({ children }: EphemeralProviderProps) => {
   useEffect(() => {
     const fetchTimer = setInterval(async () => {
       await ephemeral.fetchStatus();
-    }, 10000);
+    }, 60000);
 
     return () => clearInterval(fetchTimer);
   }, [ephemeral]);
@@ -111,7 +111,7 @@ export const EphemeralProvider = ({ children }: EphemeralProviderProps) => {
     if (status.status === 'STOPPED') {
       const fetchTimer = setInterval(async () => {
         await ephemeral.fetchStatus();
-      }, 10000);
+      }, 30000);
 
       return () => clearInterval(fetchTimer);
     }


### PR DESCRIPTION
This pull request includes changes to the `EphemeralProvider` component in the `src/common/context/EphemeralContext.tsx` file to adjust the intervals for fetching status updates. The most important changes include increasing the interval durations to reduce the frequency of status fetches.

Interval adjustments:

* Increased the interval for the main `fetchStatus` call from 10 seconds to 60 seconds.
* Increased the interval for the `fetchStatus` call when the status is 'STOPPED' from 10 seconds to 30 seconds.