### PR TITLE
Removes debug logging from EphemeralProvider

### DIFF
--- a/src/common/context/EphemeralContext.tsx
+++ b/src/common/context/EphemeralContext.tsx
@@ -65,11 +65,6 @@ export const EphemeralProvider = ({ children }: EphemeralProviderProps) => {
 
   const [hasFetchedStatus, setHasFetchedStatus] = useState(false);
 
-  console.log({
-    statusState: statusState,
-    hasFetchedStatus,
-  });
-
   useEffect(() => {
     if (
       (statusState.signIn.status || statusState.refreshSession.loading) &&


### PR DESCRIPTION
This pull request includes a small change to the `src/common/context/EphemeralContext.tsx` file. The change removes a console log statement that was used for debugging purposes.

* [`src/common/context/EphemeralContext.tsx`](diffhunk://#diff-d38cddba3297dc5b1983b16fe132e6c115e8045301e37301ee0fd3ed748fd43bL68-L72): Removed console log statement that logged `statusState` and `hasFetchedStatus` for debugging.