### PR TITLE
Adds hours to countdown display

### DIFF
--- a/src/common/context/EphemeralContext.tsx
+++ b/src/common/context/EphemeralContext.tsx
@@ -154,9 +154,12 @@ export const EphemeralProvider = ({ children }: EphemeralProviderProps) => {
 
   const formattedCountdown = useMemo(() => {
     if (countdown === null) return '';
+    const hours = Math.floor(
+      (countdown % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+    );
     const minutes = Math.floor((countdown % (1000 * 60 * 60)) / (1000 * 60));
     const seconds = Math.floor((countdown % (1000 * 60)) / 1000);
-    return `${minutes}m ${seconds}s`;
+    return `${hours > 0 ? `${hours}h ` : ''}${minutes}m ${seconds}s`;
   }, [countdown]);
 
   const countdownColor = useMemo(() => {


### PR DESCRIPTION
This pull request includes a small change to the `src/common/context/EphemeralContext.tsx` file. The change enhances the countdown timer display by adding hours to the formatted countdown if the countdown exceeds one hour.

* [`src/common/context/EphemeralContext.tsx`](diffhunk://#diff-d38cddba3297dc5b1983b16fe132e6c115e8045301e37301ee0fd3ed748fd43bR157-R162): Modified the `formattedCountdown` to include hours if the countdown is more than one hour.