### PR TITLE
Adds environment variables to skip specific Terrascan rules

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -44,6 +44,8 @@ jobs:
             6.0.x
       - name: Run Microsoft Security DevOps
         uses: microsoft/security-devops-action@08976cb623803b1b36d7112d4ff9f59eae704de0
+        env:
+          terrascan_SkipRules: 'CKV_SECRET_9,CKV_SECRET_6'
         id: msdo
       - name: Upload results to Security tab
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/defender-for-devops.yml` file. The change sets environment variables to skip specific rules when running Microsoft Security DevOps.

* [`.github/workflows/defender-for-devops.yml`](diffhunk://#diff-71b69d767f4e5c498496c11436abd5218311582fbf6470905dca7b40cddad17bR47-R48): Added `terrascan_SkipRules` environment variable to skip rules `CKV_SECRET_9` and `CKV_SECRET_6`.