### PR TITLE
Feature/password UI dark mode

### DIFF
--- a/src/common/components/Input/PasswordInput.tsx
+++ b/src/common/components/Input/PasswordInput.tsx
@@ -8,6 +8,7 @@ interface IPropsPassword {
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   styles?: string;
   placeholder?: string;
+  darkMode?: boolean;
 }
 
 function PasswordInput({
@@ -15,6 +16,7 @@ function PasswordInput({
   styles,
   onChange,
   placeholder = 'Password',
+  darkMode = false,
 }: IPropsPassword) {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -24,11 +26,17 @@ function PasswordInput({
 
   return (
     <div
-      className={`flex items-center border-2 px-3 rounded-md bg-white ${styles}`}
+      className={`flex items-center border-2 px-3 rounded-md ${
+        darkMode ? 'bg-background text-white' : 'bg-white text-black'
+      } ${styles}`}
     >
-      <Lock className="h-5 w-5 text-gray-400" />
+      <Lock
+        className={`w-5 h-5 ${darkMode ? 'text-gray-200' : 'text-gray-400'}`}
+      />
       <Input
-        className="pl-2 border-none focus-visible:ring-0 bg-white text-black"
+        className={`pl-2 ${
+          darkMode ? 'bg-background text-white' : 'bg-white text-black'
+        } border-none focus-visible:ring-0`}
         type={showPassword ? 'text' : 'password'}
         name="password"
         placeholder={placeholder}
@@ -38,9 +46,15 @@ function PasswordInput({
       />
       <div>
         {showPassword ? (
-          <EyeOff className="h-5 w-5 text-black" onClick={toggleShowPassword} />
+          <EyeOff
+            className={`w-5 h-5 ${darkMode ? 'text-white' : 'text-black'}`}
+            onClick={toggleShowPassword}
+          />
         ) : (
-          <Eye className="h-5 w-5 text-black" onClick={toggleShowPassword} />
+          <Eye
+            className={`w-5 h-5 ${darkMode ? 'text-white' : 'text-black'}`}
+            onClick={toggleShowPassword}
+          />
         )}
       </div>
     </div>

--- a/src/pages/auth/changePassword.tsx
+++ b/src/pages/auth/changePassword.tsx
@@ -99,28 +99,29 @@ function ChangePassword() {
 
   return (
     <div
-      className="flex flex-col items-center justify-center w-full h-full m-10"
+      className="flex flex-col items-center justify-center w-full h-full p-10 "
       data-test="change-password-container"
     >
       <form
-        className="flex flex-col w-full h-full gap-4 p-6 font-bold border-2 border-solid rounded-lg shadow-lg border-offset-background max-w-prose"
+        className="flex flex-col w-full gap-1 p-8 font-bold border-2 border-solid rounded-lg shadow-lg border-offset-background max-w-prose"
         onSubmit={handleSubmit(onSubmit)}
         data-test="change-password-form-container"
       >
         <h1
-          className="text-xl font-bold mb-7"
+          className="mb-8 text-2xl font-bold text-center"
           data-test="change-password-title"
         >
           Change Password
         </h1>
         {inputs.map((input: Input) => (
-          <div className="flex flex-col mb-4" key={input.name}>
+          <div className="flex flex-col mb-6" key={input.name}>
             <Controller
               control={control}
               name={input.name}
               rules={input.rules}
               render={({ field }) => (
                 <PasswordInput
+                  darkMode
                   value={field.value}
                   onChange={field.onChange}
                   placeholder={input.placeholder}
@@ -131,7 +132,7 @@ function ChangePassword() {
               <ErrorMessage
                 message={errors[input.name]?.message as string}
                 testName={`${input.test}-error`}
-                styles="text-sm"
+                styles="text-sm mt-2"
                 type={`${input.rules.pattern ? 'password' : ''}`}
               />
             )}
@@ -150,10 +151,11 @@ function ChangePassword() {
               }
               testName="change-password-error-message"
             />
-          )}{' '}
+          )}
         <Button
           type="submit"
-          className={`w-full font-semibold ${
+          variant="outline"
+          className={`w-auto px-8 py-3 font-bold transition-all duration-300 ease-in-out transform border-2 shadow-md hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
             statusState.changePassword.error ? 'mt-4' : ''
           }`}
           data-test="change-password-btn-submit"


### PR DESCRIPTION
This pull request introduces a new dark mode feature for the `PasswordInput` component and makes several style adjustments to the `ChangePassword` page. Below are the most important changes:

### Dark Mode Implementation:

* Added a `darkMode` prop to the `IPropsPassword` interface and set its default value to `false` in the `PasswordInput` component. This prop controls the dark mode styling.
* Updated the `PasswordInput` component to apply different styles based on the `darkMode` prop. This includes changes to the background, text, and icon colors. [[1]](diffhunk://#diff-11124fadeba18b39ae2442fd7e8ab88d9bb93845fd259677417155a27090b660L27-R39) [[2]](diffhunk://#diff-11124fadeba18b39ae2442fd7e8ab88d9bb93845fd259677417155a27090b660L41-R57)

### Style Adjustments:

* Modified the `ChangePassword` page container and form styles for a more polished look. Changes include adjusting padding, margin, and font sizes.
* Added a `darkMode` prop to the `PasswordInput` component used in the `ChangePassword` page to enable dark mode.
* Updated the `ErrorMessage` component styles to include a top margin for better spacing.
* Changed the `Button` component in the `ChangePassword` page to use the `outline` variant and added transition effects for better user interaction.